### PR TITLE
Fix: empty release name handled 

### DIFF
--- a/api/RestHandler.go
+++ b/api/RestHandler.go
@@ -64,7 +64,7 @@ func (impl RestHandlerImpl) WriteJsonResp(w http.ResponseWriter, err error, resp
 	}
 	b, err := json.Marshal(response)
 	if err != nil {
-		impl.logger.Error("error in marshaling err object", err)
+		impl.logger.Errorw("error in marshaling err object", "err", err)
 		status = 500
 	}
 	w.Header().Set("Content-Type", "application/json")

--- a/pkg/ReleaseNoteService.go
+++ b/pkg/ReleaseNoteService.go
@@ -170,13 +170,33 @@ func (impl *ReleaseNoteServiceImpl) GetReleases() ([]*common.Release, error) {
 			result := &common.ReleaseList{}
 			var releasesDto []*common.Release
 			for _, item := range releases {
+				var tagName, releaseName, body, tagLink string
+				var createdAt, publishedAt time.Time
+				if item.TagName != nil {
+					tagName = *item.TagName
+				}
+				if item.Name != nil {
+					releaseName = *item.Name
+				}
+				if item.Body != nil {
+					body = *item.Body
+				}
+				if item.TagName != nil {
+					tagLink = fmt.Sprintf("%s/%s", TagLink, *item.TagName)
+				}
+				if item.CreatedAt != nil {
+					createdAt = item.CreatedAt.Time
+				}
+				if item.PublishedAt != nil {
+					publishedAt = item.PublishedAt.Time
+				}
 				dto := &common.Release{
-					TagName:     *item.TagName,
-					ReleaseName: *item.Name,
-					CreatedAt:   item.CreatedAt.Time,
-					PublishedAt: item.PublishedAt.Time,
-					Body:        *item.Body,
-					TagLink:     fmt.Sprintf("%s/%s", TagLink, *item.TagName),
+					TagName:     tagName,
+					ReleaseName: releaseName,
+					CreatedAt:   createdAt,
+					PublishedAt: publishedAt,
+					Body:        body,
+					TagLink:     tagLink,
 				}
 				impl.getPrerequisiteContent(dto)
 				releasesDto = append(releasesDto, dto)

--- a/pkg/ReleaseNoteService.go
+++ b/pkg/ReleaseNoteService.go
@@ -113,7 +113,8 @@ func (impl *ReleaseNoteServiceImpl) UpdateReleases(requestBodyBytes []byte) (boo
 
 	isNew := true
 	for _, release := range releaseList {
-		if release.ReleaseName == releaseInfo.ReleaseName {
+		// tag is mandatory while drafting a new release
+		if release.TagName == releaseInfo.TagName {
 			release.Body = releaseInfo.Body
 			isNew = false
 		}

--- a/pkg/ReleaseNoteService.go
+++ b/pkg/ReleaseNoteService.go
@@ -102,7 +102,6 @@ func (impl *ReleaseNoteServiceImpl) UpdateReleases(requestBodyBytes []byte) (boo
 			impl.logger.Error("Can't assert, handle err")
 			return false, nil
 		}
-		impl.logger.Info(itemMap)
 		if itemMap != nil {
 			items := itemMap["releases"]
 			if items.Object != nil {
@@ -137,7 +136,6 @@ func (impl *ReleaseNoteServiceImpl) GetReleases() ([]*common.Release, error) {
 			impl.logger.Error("Can't assert, handle err")
 			return releaseList, nil
 		}
-		impl.logger.Info(itemMap)
 		if itemMap != nil {
 			items := itemMap["releases"]
 			if items.Object != nil {
@@ -170,6 +168,10 @@ func (impl *ReleaseNoteServiceImpl) GetReleases() ([]*common.Release, error) {
 			result := &common.ReleaseList{}
 			var releasesDto []*common.Release
 			for _, item := range releases {
+				if item == nil {
+					impl.logger.Warnw("error while getting release from repository", "err", err)
+					continue
+				}
 				var tagName, releaseName, body, tagLink string
 				var createdAt, publishedAt time.Time
 				if item.TagName != nil {

--- a/pkg/ReleaseNoteService.go
+++ b/pkg/ReleaseNoteService.go
@@ -115,6 +115,7 @@ func (impl *ReleaseNoteServiceImpl) UpdateReleases(requestBodyBytes []byte) (boo
 	for _, release := range releaseList {
 		// tag is mandatory while drafting a new release
 		if release.TagName == releaseInfo.TagName {
+			release.ReleaseName = releaseInfo.ReleaseName
 			release.Body = releaseInfo.Body
 			isNew = false
 		}


### PR DESCRIPTION
# Description

Empty release name on Published and Edited event from github trouble central api into crashloop.


Fixes #: https://dev.azure.com/DevtronLabs/Devtron/_workitems/edit/1275

## How Has This Been Tested?
<!--test-cases
- [ ] Update release on github
- [ ] Draft new release and Fetch releases
-->

## Checklist:

* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] Does this PR requires documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] I have performed a self-review of my own code.
* [ ] I have commented my code, particularly in hard-to-understand areas.
* [ ] I have tested it for all user roles.
* [ ] I have added all the required unit/api test cases.

## Does this PR introduce a user-facing change?
<!--
If NO, leave the release-note block blank.
If YES, a release note is required:
Enter your extended release note in the block below. If the PR requires additional manual action from users switching to the new version, include the string "action-required".

-->
```release-note

```
